### PR TITLE
fix: pass user id to customer panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,7 +151,7 @@ export default function App() {
               path="/customer"
               element={
                 <ProtectedRoute when={!!session} redirect="/">
-                  <CustomerPanel profile={profile} />
+                  <CustomerPanel userId={profile?.id} />
                 </ProtectedRoute>
               }
             />

--- a/src/pages/CustomerPanel.jsx
+++ b/src/pages/CustomerPanel.jsx
@@ -6,6 +6,8 @@ export default function CustomerPanel({ userId }) {
   const [orders, setOrders] = useState([]);
 
   useEffect(() => {
+    if (!userId) return;
+
     // 🔹 pobierz zamówienia na start
     const fetchOrders = async () => {
       let { data, error } = await supabase


### PR DESCRIPTION
## Co i dlaczego
- przekazuję do `CustomerPanel` identyfikator użytkownika zamiast całego profilu, aby komponent korzystał tylko z potrzebnych danych
- dodaję warunek strażnika w `CustomerPanel`, żeby nie inicjować kanału Supabase zanim znamy `userId`

## Checklist
- [x] `npm ci`
- [x] `npm run lint --if-present`
- [x] `npm run build --if-present` _(Tailwind wypisuje błąd dla `bg-neutral-950`, ale komenda kończy się sukcesem)_
- [x] `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68cfa0f7ab28832eb1f65ffbdb9d22b3