### PR TITLE
fix: przekaż profil do BusinessPanel jako user

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,7 +161,7 @@ export default function App() {
               path="/business"
               element={
                 <ProtectedRoute when={!!session && isBiz} redirect="/customer">
-                  <BusinessPanel profile={profile} />
+                  <BusinessPanel user={profile} />
                 </ProtectedRoute>
               }
             />


### PR DESCRIPTION
## Opis
- Zamieniono przekazywany props na `user` w trasie panelu biznesowego, aby komponent otrzymywał oczekiwany obiekt profilu.

## Checklist
- [x] npm ci
- [x] npm run lint --if-present
- [x] npm run build --if-present
- [x] npm test --if-present

------
https://chatgpt.com/codex/tasks/task_e_68cfa1e304ac832ea2c5ac2c2753d01c