### PR TITLE
fix: update React entry comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
     <div id="root"></div>
 
     <!-- Wejście aplikacji – Vite podmieni to na hashowane pliki w produkcji -->
-    <!-- Dla React: /src/main.tsx; dla Svelte/Vue: /src/main.ts -->
+    <!-- Dla React: /src/main.jsx; dla Svelte/Vue: /src/main.ts -->
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Co i dlaczego
- Doprecyzowałem komentarz w `index.html`, aby wskazywał, że aplikacja React korzysta z `src/main.jsx`, zgodnie z konfiguracją wejścia używaną przez Vite.

## Checklista
- [x] `npm ci && npm run lint --if-present && npm run build --if-present && npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68cfbc7cc8f0832e9651708ec99ee67a