### PR TITLE
feat: popraw responsywność hero

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,8 +23,8 @@
 /* ===== Responsive layout overrides (frontend spec) ===== */
 html, body { overflow-x: hidden; }
 
-/* Logo scaling: default ~40% width (max 250px); on small screens up to 60% (max 180px) */
-.ff-logo { max-width: 250px; width: 40%; height: auto; }
+/* Logo scaling: default ~54% width (max 335px); on small screens up to 80% (max 240px) */
+.ff-logo { max-width: 335px; width: 54%; height: auto; }
 
 /* Central container width and spacing */
 .ff-stack { width: 100%; max-width: min(760px, 92vw); margin-inline: auto; }
@@ -32,9 +32,14 @@ html, body { overflow-x: hidden; }
 
 /* Search input sizing on small screens */
 @media (max-width: 768px) {
-  .ff-logo { max-width: 180px; width: 60%; }
+  .ff-logo { max-width: 240px; width: 80%; }
   .ff-search { width: 90%; grid-template-columns: 1fr auto; }
   .ff-input { width: 100%; font-size: 0.9rem; }
+}
+
+.ff-hero { padding: 4.5vh 12px 7vh; }
+
+@media (min-width: 640px) {
   .ff-hero { padding: 6vh 12px 10vh; }
 }
 

--- a/src/pages/HomeClassic.jsx
+++ b/src/pages/HomeClassic.jsx
@@ -494,7 +494,7 @@ export default function HomeClassic() {
   }
 
   return (
-    <section className="ff-hero min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 relative overflow-hidden">
+    <section className="ff-hero min-h-[82vh] sm:min-h-[76vh] bg-gradient-to-br from-gray-900 via-black to-gray-900 relative overflow-hidden">
       {/* Animated background elements */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <motion.div
@@ -571,32 +571,32 @@ export default function HomeClassic() {
         </AnimatePresence>
 
         {/* Główna zawartość */}
-        <div className="ff-main-content">
+        <div className="ff-main-content pb-14 sm:pb-12">
           {/* Stos: logo + szukajka */}
-          <div className="ff-stack pt-20">
-        <motion.div 
-          className="ff-logo-wrap flex justify-center mb-8"
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 0.5 }}
-        >
-          <motion.div
-            className="relative"
-            animate={recording ? {
-              scale: [1, 1.05, 1],
-            } : speaking ? {
-              scale: [1, 1.02, 1],
-            } : {}}
-            transition={recording ? {
-              duration: 1,
-              repeat: Infinity,
-              ease: "easeInOut"
-            } : speaking ? {
-              duration: 0.8,
-              repeat: Infinity,
-              ease: "easeInOut"
-            } : {}}
-          >
+          <div className="ff-stack pt-12 sm:pt-16">
+            <motion.div
+              className="ff-logo-wrap flex justify-center mb-6"
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.5 }}
+            >
+              <motion.div
+                className="relative"
+                animate={recording ? {
+                  scale: [1, 1.05, 1],
+                } : speaking ? {
+                  scale: [1, 1.02, 1],
+                } : {}}
+                transition={recording ? {
+                  duration: 1,
+                  repeat: Infinity,
+                  ease: "easeInOut"
+                } : speaking ? {
+                  duration: 0.8,
+                  repeat: Infinity,
+                  ease: "easeInOut"
+                } : {}}
+              >
             {/* Animated glow rings */}
             {recording && (
               <>
@@ -695,8 +695,8 @@ export default function HomeClassic() {
           {/* Voice indicator */}
           <AnimatePresence>
             {recording && (
-              <motion.div 
-                className="absolute -bottom-8 left-1/2 transform -translate-x-1/2 text-sm text-brand-400 flex items-center gap-2"
+              <motion.div
+                className="absolute bottom-2 sm:bottom-3 left-1/2 transform -translate-x-1/2 text-sm text-brand-400 flex items-center gap-2"
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -10 }}
@@ -718,7 +718,7 @@ export default function HomeClassic() {
       <AnimatePresence>
         {!!chat.length && (
           <motion.div 
-            className="ff-chat mt-8 space-y-4" 
+            className="ff-chat mt-6 space-y-4"
             aria-live="polite"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}


### PR DESCRIPTION
## Co i dlaczego
- obniżyłem mobilną wysokość hero i dodałem dodatkowy dolny padding, aby stos i wskaźnik nagrywania nie stykały się z krawędzią ekranu
- wyrównałem mobilne odstępy (pt/bottom) i doprecyzowałem padding `.ff-hero`, żeby układ zachował proporcje również na desktopie

## Checklist
- [ ] `npm ci` *(błąd: package-lock.json pomija zależności z package.json — patrz log)*
- [ ] `npm run lint --if-present` *(błąd: brak zainstalowanych pakietów po nieudanym `npm ci`)*
- [ ] `npm run build --if-present` *(błąd: brak polecenia `vite` bez zainstalowanych paczek)*
- [ ] `npm test --if-present` *(nie uruchomiono – brak zależności po nieudanym `npm ci`)*

------
https://chatgpt.com/codex/tasks/task_e_68de665416d0832ea15d39f69225d7f5